### PR TITLE
Use JsonResponse instead response() helper

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -377,6 +377,6 @@ class Response
      */
     protected function response($data = [], $status = 200, array $headers = [], $options = 0): JsonResponse
     {
-        return response()->json($data, $status, $headers, $options);
+        return new JsonResponse($data, $status, $headers, $options);
     }
 }


### PR DESCRIPTION
Currently in Laravel call response() return ResponseFactory. This class inject ViewFactory which use blade engine. If we change to JsonResponse we can complete disable blade in Laravel.