### PR TITLE
Always include 'links' in PaginatedResponse

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -282,6 +282,10 @@ class Response
                     'count' => $paginated['to'] ?? null,
                     'per_page' => $paginated['per_page'] ?? null,
                     'current_page' => $paginated['current_page'] ?? null,
+                    'links' => [
+                        'previous' => $previous,
+                        'next' => $next,
+                    ],
                 ],
             ],
         ];
@@ -292,13 +296,6 @@ class Response
 
         if ($totalPages) {
             $paginationInformation['meta']['pagination']['total_pages'] = $totalPages;
-        }
-
-        if ($previous || $next) {
-            $paginationInformation['meta']['pagination']['links'] = [
-                'previous' => $previous,
-                'next' => $next,
-            ];
         }
 
         return $paginationInformation;


### PR DESCRIPTION
When working with PaginatedResponse, i feel it hard to check we have next page or not