### PR TITLE
修复 `JsonResource` 响应类型判断条件

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -187,7 +187,7 @@ class Response
             return $this->formatResourceCollectionResponse(...func_get_args());
         }
 
-        if ($data instanceof JsonResource) {
+        if ($data instanceof JsonResource || $data instanceof \Illuminate\Http\Resources\Json\JsonResource) {
             return $this->formatResourceResponse(...func_get_args());
         }
 


### PR DESCRIPTION
laravel `8.58.0` 版本没有 `Illuminate\Http\Resources\Json\Resource` 类，而是 `\Illuminate\Http\Resources\Json\JsonResource`。