### PR TITLE
优化格式化类配置

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload": {
         "psr-4": {
             "Jiannei\\Response\\Laravel\\": "src"
-        }
+        },
+        "files": [
+            "src/Support/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/response.php
+++ b/config/response.php
@@ -52,8 +52,8 @@ return [
 
     // Set the structure of the response data
     'format' => [
-        \Jiannei\Response\Laravel\Support\Format::class,
-        [
+        'class' => \Jiannei\Response\Laravel\Support\Format::class,
+        'config' => [
             'status' => ['alias' => 'status', 'show' => true],
             'code' => ['alias' => 'code', 'show' => true],
             'message' => ['alias' => 'message', 'show' => true],

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -11,7 +11,9 @@
 
 namespace Jiannei\Response\Laravel\Providers;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use Jiannei\Response\Laravel\Contracts\Format;
 
 class LaravelServiceProvider extends ServiceProvider
 {
@@ -22,14 +24,9 @@ class LaravelServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $formatter = $this->app['config']->get('response.format.0', \Jiannei\Response\Laravel\Support\Format::class);
-        $config = $this->app['config']->get('response.format.1', []);
-
-        if (is_string($formatter) && class_exists($formatter)) {
-            $this->app->bind(\Jiannei\Response\Laravel\Contracts\Format::class, function () use ($formatter, $config) {
-                return new $formatter($config);
-            });
-        }
+        $this->app->bind(Format::class, function (){
+            return make(config('response.format'));
+        });
     }
 
     protected function setupConfig()

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+if (! function_exists('make')) {
+    /**
+     * @psalm-param string|array<string, mixed> $abstract
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    function make($abstract, array $parameters = [])
+    {
+        if (! in_array(gettype($abstract), ['string', 'array'])) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid argument type(string/array): %s.', gettype($abstract))
+            );
+        }
+
+        if (is_string($abstract)) {
+            return app($abstract, $parameters);
+        }
+
+        $classes = ['__class', '_class', 'class'];
+        foreach ($classes as $class) {
+            if (! isset($abstract[$class])) {
+                continue;
+            }
+
+            $parameters = Arr::except($abstract, $class) + $parameters;
+            $abstract = $abstract[$class];
+
+            return make($abstract, $parameters);
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('The argument of abstract must be an array containing a `%s` element.', implode('` or `', $classes))
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,7 +44,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $app['config']->set('response.enum', \Jiannei\Response\Laravel\Tests\Repositories\Enums\ResponseCodeEnum::class);
         if ($this instanceof FormatTest) {
-            $app['config']->set('response.format', [\Jiannei\Response\Laravel\Tests\Support\Format::class]);
+            $app['config']->set('response.format', [
+                'class' => \Jiannei\Response\Laravel\Tests\Support\Format::class
+            ]);
         }
     }
 }


### PR DESCRIPTION
新增了一个 `make` 函数，类似 laravel 的 `app()->make()` 的方法。

格式化类的创建由数字下标获取参数创建改为参数名称获取。这样更改更具有表达力和普适性。例如自定义的类没有依赖、或者依赖是可注入的，直接配置该类依然是适用的。

```php
'format' => MyFormat::class,
```